### PR TITLE
Apply policy for com.atomist:spring-boot-agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
          <groupId>com.atomist</groupId>
          <artifactId>spring-boot-agent</artifactId>
-         <version>_[0.1.5,1.0.0)</version>
+         <version>[0.1.5,1.0.0)</version>
       </dependency>
    </dependencies>
    <build>


### PR DESCRIPTION
Apply policy `maven-direct-dep::com.atomist:spring-boot-agent`:

**New Maven Dependency Policy**
Policy version for Maven dependency *com.atomist/spring-boot-agent* is `[0.1.5,1.0.0)`.
Project *sdm-org/cd41/master* is currently configured to use version `_[0.1.5,1.0.0)`.

_Direct Maven dependencies_
```com.atomist:spring-boot-agent ([0.1.5,1.0.0))```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:maven-direct-dep::com.atomist:spring-boot-agent=6b8e590ba78c821d8172200fb838dbffd41e06b9cca542b84364402e70954a2c]</code>
</details>