### PR TITLE
Apply policy for com.atomist:spring-boot-agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
          <groupId>com.atomist</groupId>
          <artifactId>spring-boot-agent</artifactId>
-         <version>[2.0.1,3.0.0)</version>
+         <version>[2.0.0,3.0.0)</version>
       </dependency>
       <dependency>
          <groupId>io.sentry</groupId>


### PR DESCRIPTION
Apply policy `maven-direct-dep::com.atomist:spring-boot-agent`:

**New Maven Dependency Version Policy**
Policy version for Maven dependency *com.atomist:spring-boot-agent* is `[2.0.0,3.0.0)`.
Project *sdm-org/cd41/master* is currently using version `[2.0.1,3.0.0)`.

_Maven declared dependencies_
```com.atomist:spring-boot-agent ([2.0.0,3.0.0))```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:maven-direct-dep::com.atomist:spring-boot-agent=ea440210452167749460b2c005f1e4b5e532d26352868c77bef3489f5d8e0e5c]</code>
</details>