### PR TITLE
Apply policy for io.sentry:sentry-spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
       <dependency>
          <groupId>io.sentry</groupId>
          <artifactId>sentry-spring</artifactId>
-         <version>1.7.4</version>
+         <version>1.7.5</version>
       </dependency>
    </dependencies>
    <build>


### PR DESCRIPTION
Apply policy `maven-direct-dep::io.sentry:sentry-spring`:

**New Maven Dependency Version Policy**
Policy version for Maven dependency *io.sentry:sentry-spring* is `1.7.5`.
Project *sdm-org/cd41/atomist/maven-direct-dep/master* is currently using version `1.7.4`.

_Maven declared dependencies_
```io.sentry:sentry-spring (1.7.5)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:maven-direct-dep::io.sentry:sentry-spring=6de1c3548ce6efc4c28e099564931e72b0a0e067f7f3ef4a0ef4ca94f179f918]</code>
</details>