### PR TITLE
Apply policy for org.springframework.boot:spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>2.1.0.RELEASE</version>
+      <version>2.1.6.RELEASE</version>
       <relativePath />  
    </parent>
    <properties> 


### PR DESCRIPTION
Apply policy `maven-parent-pom::org.springframework.boot:spring-boot-starter-parent`:

**New Maven Parent POM Version Policy**
Policy version for Maven dependency *org.springframework.boot:spring-boot-starter-parent* is `2.1.6.RELEASE`.
Project *sdm-org/cd41/master* is currently using version `2.1.0.RELEASE`.

_Maven parent POM_
```org.springframework.boot:spring-boot-starter-parent (2.1.6.RELEASE)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:maven-parent-pom::org.springframework.boot:spring-boot-starter-parent=775d913232add75f34dc52fae8d45aae88a2cce991b2e20b0f57c522ad1f3d1a]</code>
</details>