### PR TITLE
Apply all of com.atomist:spring-boot-agent, io.sentry:sentry-spring, org.springframework.boot:spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>2.1.0.RELEASE</version>
+      <version>2.1.6.RELEASE</version>
       <relativePath />  
    </parent>
    <properties> 
@@ -36,12 +36,12 @@
       <dependency>
          <groupId>com.atomist</groupId>
          <artifactId>spring-boot-agent</artifactId>
-         <version>[2.0.1,3.0.0)</version>
+         <version>[2.0.0,3.0.0)</version>
       </dependency>
       <dependency>
          <groupId>io.sentry</groupId>
          <artifactId>sentry-spring</artifactId>
-         <version>1.7.4</version>
+         <version>1.7.5</version>
       </dependency>
    </dependencies>
    <build>


### PR DESCRIPTION
Apply policy `maven-direct-dep::com.atomist:spring-boot-agent`:

**New Maven Dependency Version Policy**
Policy version for Maven dependency *com.atomist:spring-boot-agent* is `[2.0.0,3.0.0)`.
Project *sdm-org/cd41/master* is currently using version `[2.0.1,3.0.0)`.

_Maven declared dependencies_
```com.atomist:spring-boot-agent ([2.0.0,3.0.0))```

---
Apply policy `maven-direct-dep::io.sentry:sentry-spring`:

**New Maven Dependency Version Policy**
Policy version for Maven dependency *io.sentry:sentry-spring* is `1.7.5`.
Project *sdm-org/cd41/master* is currently using version `1.7.4`.

_Maven declared dependencies_
```io.sentry:sentry-spring (1.7.5)```

---
Apply policy `maven-parent-pom::org.springframework.boot:spring-boot-starter-parent`:

**New Maven Parent POM Version Policy**
Policy version for Maven dependency *org.springframework.boot:spring-boot-starter-parent* is `2.1.6.RELEASE`.
Project *sdm-org/cd41/master* is currently using version `2.1.0.RELEASE`.

_Maven parent POM_
```org.springframework.boot:spring-boot-starter-parent (2.1.6.RELEASE)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:maven-direct-dep::com.atomist:spring-boot-agent=ea440210452167749460b2c005f1e4b5e532d26352868c77bef3489f5d8e0e5c]</code><br/><code>[fingerprint:maven-direct-dep::io.sentry:sentry-spring=6de1c3548ce6efc4c28e099564931e72b0a0e067f7f3ef4a0ef4ca94f179f918]</code><br/><code>[fingerprint:maven-parent-pom::org.springframework.boot:spring-boot-starter-parent=775d913232add75f34dc52fae8d45aae88a2cce991b2e20b0f57c522ad1f3d1a]</code>
</details>